### PR TITLE
Changed _pools initialization to an empty object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ var PG = function(clientConstructor) {
   this.Client = clientConstructor;
   this.Query = this.Client.Query;
   this.Pool = poolFactory(this.Client);
-  this._pools = [];
+  this._pools = {};
   this.Connection = Connection;
   this.types = require('pg-types');
 };


### PR DESCRIPTION
### What happens?

_pools is initialized as an empty array but values are stored and retrieved as object keys.

For example I have an object that looks like this in the inspector:

``` javascript
_pools: Array[0]
  "postgres://<snip>": Object
  length: 0
```
### What did you expect to happen?

I'm not sure if this is by design or not. I was expecting an easily-iterable object of some sort, either an array of objects or a plain object with keys. Sure, I could iterate over the Array instance's own keys but that's messy. It feels like this should just have been instantiated as an object.
### Use case

I understand this is a private variable. I use it to inspect the pool level for debugging and performance purposes only.

Thank you for your time and for such a great open source project! 🍻 
